### PR TITLE
Player Inventory loot filter

### DIFF
--- a/Config.yaml
+++ b/Config.yaml
@@ -200,6 +200,8 @@ ItemLog:
   Enabled: true
   Position: TopLeft
   FilterFileName: ItemFilter.yaml
+  CheckVendorTrade: true
+  CheckItemOnIdentify: true
   PlaySoundOnDrop: true
   SoundFile: ''
   SoundVolume: 100

--- a/Config.yaml
+++ b/Config.yaml
@@ -200,7 +200,7 @@ ItemLog:
   Enabled: true
   Position: TopLeft
   FilterFileName: ItemFilter.yaml
-  CheckVendorTrade: true
+  CheckVendorItems: true
   CheckItemOnIdentify: true
   PlaySoundOnDrop: true
   SoundFile: ''

--- a/ConfigEditor.Designer.cs
+++ b/ConfigEditor.Designer.cs
@@ -151,6 +151,8 @@
             this.btnAddHidden = new System.Windows.Forms.Button();
             this.lstHidden = new System.Windows.Forms.ListBox();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
+            this.chkItemLogItemsOnIdentify = new System.Windows.Forms.CheckBox();
+            this.chkItemLogVendorTrade = new System.Windows.Forms.CheckBox();
             this.tabControl1.SuspendLayout();
             this.tabPage5.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -603,7 +605,7 @@
             // chkStickToLastGameWindow
             // 
             this.chkStickToLastGameWindow.AutoSize = true;
-            this.chkStickToLastGameWindow.Location = new System.Drawing.Point(9, 264);
+            this.chkStickToLastGameWindow.Location = new System.Drawing.Point(10, 264);
             this.chkStickToLastGameWindow.Name = "chkStickToLastGameWindow";
             this.chkStickToLastGameWindow.Size = new System.Drawing.Size(222, 17);
             this.chkStickToLastGameWindow.TabIndex = 25;
@@ -817,7 +819,7 @@
             // chkToggleViaPanels
             // 
             this.chkToggleViaPanels.AutoSize = true;
-            this.chkToggleViaPanels.Location = new System.Drawing.Point(9, 241);
+            this.chkToggleViaPanels.Location = new System.Drawing.Point(10, 241);
             this.chkToggleViaPanels.Name = "chkToggleViaPanels";
             this.chkToggleViaPanels.Size = new System.Drawing.Size(196, 17);
             this.chkToggleViaPanels.TabIndex = 9;
@@ -1221,6 +1223,8 @@
             // 
             // tabPage6
             // 
+            this.tabPage6.Controls.Add(this.chkItemLogVendorTrade);
+            this.tabPage6.Controls.Add(this.chkItemLogItemsOnIdentify);
             this.tabPage6.Controls.Add(this.cboItemLogPosition);
             this.tabPage6.Controls.Add(this.lblItemLogPosition);
             this.tabPage6.Controls.Add(this.chkLogTextShadow);
@@ -1269,7 +1273,7 @@
             // chkLogTextShadow
             // 
             this.chkLogTextShadow.AutoSize = true;
-            this.chkLogTextShadow.Location = new System.Drawing.Point(142, 273);
+            this.chkLogTextShadow.Location = new System.Drawing.Point(142, 285);
             this.chkLogTextShadow.Name = "chkLogTextShadow";
             this.chkLogTextShadow.Size = new System.Drawing.Size(89, 17);
             this.chkLogTextShadow.TabIndex = 31;
@@ -1282,7 +1286,7 @@
             this.btnClearLogFont.FlatAppearance.BorderSize = 0;
             this.btnClearLogFont.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnClearLogFont.Font = new System.Drawing.Font("Microsoft Sans Serif", 6F);
-            this.btnClearLogFont.Location = new System.Drawing.Point(89, 270);
+            this.btnClearLogFont.Location = new System.Drawing.Point(89, 282);
             this.btnClearLogFont.Name = "btnClearLogFont";
             this.btnClearLogFont.Size = new System.Drawing.Size(23, 23);
             this.btnClearLogFont.TabIndex = 30;
@@ -1294,7 +1298,7 @@
             // 
             this.lblSoundVolumeValue.AutoSize = true;
             this.lblSoundVolumeValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblSoundVolumeValue.Location = new System.Drawing.Point(279, 165);
+            this.lblSoundVolumeValue.Location = new System.Drawing.Point(279, 199);
             this.lblSoundVolumeValue.Name = "lblSoundVolumeValue";
             this.lblSoundVolumeValue.Size = new System.Drawing.Size(25, 13);
             this.lblSoundVolumeValue.TabIndex = 29;
@@ -1307,7 +1311,7 @@
             this.soundVolume.BackColor = System.Drawing.Color.White;
             this.soundVolume.Cursor = System.Windows.Forms.Cursors.Default;
             this.soundVolume.LargeChange = 1;
-            this.soundVolume.Location = new System.Drawing.Point(85, 165);
+            this.soundVolume.Location = new System.Drawing.Point(85, 199);
             this.soundVolume.Maximum = 20;
             this.soundVolume.Name = "soundVolume";
             this.soundVolume.Size = new System.Drawing.Size(188, 27);
@@ -1319,7 +1323,7 @@
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(11, 168);
+            this.label10.Location = new System.Drawing.Point(11, 202);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(42, 13);
             this.label10.TabIndex = 27;
@@ -1329,7 +1333,7 @@
             // 
             this.lblItemDisplayForSecondsValue.AutoSize = true;
             this.lblItemDisplayForSecondsValue.BackColor = System.Drawing.Color.Transparent;
-            this.lblItemDisplayForSecondsValue.Location = new System.Drawing.Point(279, 213);
+            this.lblItemDisplayForSecondsValue.Location = new System.Drawing.Point(279, 240);
             this.lblItemDisplayForSecondsValue.Name = "lblItemDisplayForSecondsValue";
             this.lblItemDisplayForSecondsValue.Size = new System.Drawing.Size(33, 13);
             this.lblItemDisplayForSecondsValue.TabIndex = 25;
@@ -1341,7 +1345,7 @@
             this.itemDisplayForSeconds.AutoSize = false;
             this.itemDisplayForSeconds.BackColor = System.Drawing.Color.White;
             this.itemDisplayForSeconds.LargeChange = 1;
-            this.itemDisplayForSeconds.Location = new System.Drawing.Point(85, 213);
+            this.itemDisplayForSeconds.Location = new System.Drawing.Point(85, 240);
             this.itemDisplayForSeconds.Maximum = 24;
             this.itemDisplayForSeconds.Minimum = 1;
             this.itemDisplayForSeconds.Name = "itemDisplayForSeconds";
@@ -1355,7 +1359,7 @@
             // btnLogFont
             // 
             this.btnLogFont.BackColor = System.Drawing.Color.Transparent;
-            this.btnLogFont.Location = new System.Drawing.Point(14, 270);
+            this.btnLogFont.Location = new System.Drawing.Point(14, 282);
             this.btnLogFont.Name = "btnLogFont";
             this.btnLogFont.Size = new System.Drawing.Size(75, 23);
             this.btnLogFont.TabIndex = 22;
@@ -1368,7 +1372,7 @@
             this.label21.AutoSize = true;
             this.label21.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F);
             this.label21.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.label21.Location = new System.Drawing.Point(82, 70);
+            this.label21.Location = new System.Drawing.Point(86, 109);
             this.label21.Name = "label21";
             this.label21.Size = new System.Drawing.Size(80, 13);
             this.label21.TabIndex = 26;
@@ -1379,7 +1383,7 @@
             this.label20.AutoSize = true;
             this.label20.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F);
             this.label20.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.label20.Location = new System.Drawing.Point(82, 137);
+            this.label20.Location = new System.Drawing.Point(86, 178);
             this.label20.Name = "label20";
             this.label20.Size = new System.Drawing.Size(115, 13);
             this.label20.TabIndex = 25;
@@ -1388,7 +1392,7 @@
             // label18
             // 
             this.label18.AutoSize = true;
-            this.label18.Location = new System.Drawing.Point(11, 216);
+            this.label18.Location = new System.Drawing.Point(11, 243);
             this.label18.Name = "label18";
             this.label18.Size = new System.Drawing.Size(75, 13);
             this.label18.TabIndex = 6;
@@ -1396,9 +1400,9 @@
             // 
             // txtSoundFile
             // 
-            this.txtSoundFile.Location = new System.Drawing.Point(85, 114);
+            this.txtSoundFile.Location = new System.Drawing.Point(89, 155);
             this.txtSoundFile.Name = "txtSoundFile";
-            this.txtSoundFile.Size = new System.Drawing.Size(227, 20);
+            this.txtSoundFile.Size = new System.Drawing.Size(223, 20);
             this.txtSoundFile.TabIndex = 5;
             this.txtSoundFile.TextChanged += new System.EventHandler(this.txtSoundFile_TextChanged);
             this.txtSoundFile.LostFocus += new System.EventHandler(this.txtSoundFile_LostFocus);
@@ -1406,16 +1410,16 @@
             // label17
             // 
             this.label17.AutoSize = true;
-            this.label17.Location = new System.Drawing.Point(11, 117);
+            this.label17.Location = new System.Drawing.Point(11, 158);
             this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(60, 13);
+            this.label17.Size = new System.Drawing.Size(57, 13);
             this.label17.TabIndex = 4;
-            this.label17.Text = "Sound File:";
+            this.label17.Text = "Sound File";
             // 
             // chkPlaySound
             // 
             this.chkPlaySound.AutoSize = true;
-            this.chkPlaySound.Location = new System.Drawing.Point(14, 91);
+            this.chkPlaySound.Location = new System.Drawing.Point(14, 131);
             this.chkPlaySound.Name = "chkPlaySound";
             this.chkPlaySound.Size = new System.Drawing.Size(121, 17);
             this.chkPlaySound.TabIndex = 3;
@@ -1425,16 +1429,16 @@
             // 
             // txtFilterFile
             // 
-            this.txtFilterFile.Location = new System.Drawing.Point(85, 47);
+            this.txtFilterFile.Location = new System.Drawing.Point(89, 86);
             this.txtFilterFile.Name = "txtFilterFile";
-            this.txtFilterFile.Size = new System.Drawing.Size(227, 20);
+            this.txtFilterFile.Size = new System.Drawing.Size(223, 20);
             this.txtFilterFile.TabIndex = 2;
             this.txtFilterFile.TextChanged += new System.EventHandler(this.txtFilterFile_TextChanged);
             // 
             // label16
             // 
             this.label16.AutoSize = true;
-            this.label16.Location = new System.Drawing.Point(11, 50);
+            this.label16.Location = new System.Drawing.Point(11, 89);
             this.label16.Name = "label16";
             this.label16.Size = new System.Drawing.Size(48, 13);
             this.label16.TabIndex = 1;
@@ -1590,6 +1594,28 @@
             this.lstHidden.Name = "lstHidden";
             this.lstHidden.Size = new System.Drawing.Size(253, 160);
             this.lstHidden.TabIndex = 0;
+            // 
+            // chkItemLogItemsOnIdentify
+            // 
+            this.chkItemLogItemsOnIdentify.AutoSize = true;
+            this.chkItemLogItemsOnIdentify.Location = new System.Drawing.Point(14, 39);
+            this.chkItemLogItemsOnIdentify.Name = "chkItemLogItemsOnIdentify";
+            this.chkItemLogItemsOnIdentify.Size = new System.Drawing.Size(139, 17);
+            this.chkItemLogItemsOnIdentify.TabIndex = 39;
+            this.chkItemLogItemsOnIdentify.Text = "Check Items On Identify";
+            this.chkItemLogItemsOnIdentify.UseVisualStyleBackColor = true;
+            this.chkItemLogItemsOnIdentify.CheckedChanged += new System.EventHandler(this.chkItemLogItemsOnIdentify_CheckedChanged);
+            // 
+            // chkItemLogVendorTrade
+            // 
+            this.chkItemLogVendorTrade.AutoSize = true;
+            this.chkItemLogVendorTrade.Location = new System.Drawing.Point(14, 62);
+            this.chkItemLogVendorTrade.Name = "chkItemLogVendorTrade";
+            this.chkItemLogVendorTrade.Size = new System.Drawing.Size(153, 17);
+            this.chkItemLogVendorTrade.TabIndex = 40;
+            this.chkItemLogVendorTrade.Text = "Check Vendor Trade Items";
+            this.chkItemLogVendorTrade.UseVisualStyleBackColor = true;
+            this.chkItemLogVendorTrade.CheckedChanged += new System.EventHandler(this.chkItemLogVendorTrade_CheckedChanged);
             // 
             // ConfigEditor
             // 
@@ -1772,5 +1798,7 @@
         private System.Windows.Forms.ComboBox cboItemLogPosition;
         private System.Windows.Forms.Label lblItemLogPosition;
         private System.Windows.Forms.CheckBox chkMonsterHealthBar;
+        private System.Windows.Forms.CheckBox chkItemLogVendorTrade;
+        private System.Windows.Forms.CheckBox chkItemLogItemsOnIdentify;
     }
 }

--- a/ConfigEditor.Designer.cs
+++ b/ConfigEditor.Designer.cs
@@ -152,7 +152,7 @@
             this.lstHidden = new System.Windows.Forms.ListBox();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
             this.chkItemLogItemsOnIdentify = new System.Windows.Forms.CheckBox();
-            this.chkItemLogVendorTrade = new System.Windows.Forms.CheckBox();
+            this.chkItemLogVendorItems = new System.Windows.Forms.CheckBox();
             this.tabControl1.SuspendLayout();
             this.tabPage5.SuspendLayout();
             this.groupBox5.SuspendLayout();
@@ -1223,7 +1223,7 @@
             // 
             // tabPage6
             // 
-            this.tabPage6.Controls.Add(this.chkItemLogVendorTrade);
+            this.tabPage6.Controls.Add(this.chkItemLogVendorItems);
             this.tabPage6.Controls.Add(this.chkItemLogItemsOnIdentify);
             this.tabPage6.Controls.Add(this.cboItemLogPosition);
             this.tabPage6.Controls.Add(this.lblItemLogPosition);
@@ -1606,16 +1606,16 @@
             this.chkItemLogItemsOnIdentify.UseVisualStyleBackColor = true;
             this.chkItemLogItemsOnIdentify.CheckedChanged += new System.EventHandler(this.chkItemLogItemsOnIdentify_CheckedChanged);
             // 
-            // chkItemLogVendorTrade
+            // chkItemLogVendorItems
             // 
-            this.chkItemLogVendorTrade.AutoSize = true;
-            this.chkItemLogVendorTrade.Location = new System.Drawing.Point(14, 62);
-            this.chkItemLogVendorTrade.Name = "chkItemLogVendorTrade";
-            this.chkItemLogVendorTrade.Size = new System.Drawing.Size(153, 17);
-            this.chkItemLogVendorTrade.TabIndex = 40;
-            this.chkItemLogVendorTrade.Text = "Check Vendor Trade Items";
-            this.chkItemLogVendorTrade.UseVisualStyleBackColor = true;
-            this.chkItemLogVendorTrade.CheckedChanged += new System.EventHandler(this.chkItemLogVendorTrade_CheckedChanged);
+            this.chkItemLogVendorItems.AutoSize = true;
+            this.chkItemLogVendorItems.Location = new System.Drawing.Point(14, 62);
+            this.chkItemLogVendorItems.Name = "chkItemLogVendorItems";
+            this.chkItemLogVendorItems.Size = new System.Drawing.Size(153, 17);
+            this.chkItemLogVendorItems.TabIndex = 40;
+            this.chkItemLogVendorItems.Text = "Check Vendor Items";
+            this.chkItemLogVendorItems.UseVisualStyleBackColor = true;
+            this.chkItemLogVendorItems.CheckedChanged += new System.EventHandler(this.chkItemLogVendorItems_CheckedChanged);
             // 
             // ConfigEditor
             // 
@@ -1798,7 +1798,7 @@
         private System.Windows.Forms.ComboBox cboItemLogPosition;
         private System.Windows.Forms.Label lblItemLogPosition;
         private System.Windows.Forms.CheckBox chkMonsterHealthBar;
-        private System.Windows.Forms.CheckBox chkItemLogVendorTrade;
+        private System.Windows.Forms.CheckBox chkItemLogVendorItems;
         private System.Windows.Forms.CheckBox chkItemLogItemsOnIdentify;
     }
 }

--- a/ConfigEditor.cs
+++ b/ConfigEditor.cs
@@ -97,6 +97,8 @@ namespace MapAssist
 
             cboItemLogPosition.SelectedIndex = cboItemLogPosition.FindStringExact(MapAssistConfiguration.Loaded.ItemLog.Position.ToString().ToProperCase());
             chkItemLogEnabled.Checked = MapAssistConfiguration.Loaded.ItemLog.Enabled;
+            chkItemLogItemsOnIdentify.Checked = MapAssistConfiguration.Loaded.ItemLog.CheckItemOnIdentify;
+            chkItemLogVendorTrade.Checked = MapAssistConfiguration.Loaded.ItemLog.CheckVendorTrade;
             chkPlaySound.Checked = MapAssistConfiguration.Loaded.ItemLog.PlaySoundOnDrop;
             txtFilterFile.Text = MapAssistConfiguration.Loaded.ItemLog.FilterFileName;
             txtSoundFile.Text = MapAssistConfiguration.Loaded.ItemLog.SoundFile;
@@ -581,6 +583,16 @@ namespace MapAssist
         private void chkItemLogEnabled_CheckedChanged(object sender, EventArgs e)
         {
             MapAssistConfiguration.Loaded.ItemLog.Enabled = chkItemLogEnabled.Checked;
+        }
+
+        private void chkItemLogItemsOnIdentify_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.ItemLog.CheckItemOnIdentify = chkItemLogItemsOnIdentify.Checked;
+        }
+
+        private void chkItemLogVendorTrade_CheckedChanged(object sender, EventArgs e)
+        {
+            MapAssistConfiguration.Loaded.ItemLog.CheckVendorTrade = chkItemLogVendorTrade.Checked;
         }
 
         private void cboItemLogPosition_SelectedIndexChanged(object sender, EventArgs e)

--- a/ConfigEditor.cs
+++ b/ConfigEditor.cs
@@ -98,7 +98,7 @@ namespace MapAssist
             cboItemLogPosition.SelectedIndex = cboItemLogPosition.FindStringExact(MapAssistConfiguration.Loaded.ItemLog.Position.ToString().ToProperCase());
             chkItemLogEnabled.Checked = MapAssistConfiguration.Loaded.ItemLog.Enabled;
             chkItemLogItemsOnIdentify.Checked = MapAssistConfiguration.Loaded.ItemLog.CheckItemOnIdentify;
-            chkItemLogVendorTrade.Checked = MapAssistConfiguration.Loaded.ItemLog.CheckVendorTrade;
+            chkItemLogVendorItems.Checked = MapAssistConfiguration.Loaded.ItemLog.CheckVendorItems;
             chkPlaySound.Checked = MapAssistConfiguration.Loaded.ItemLog.PlaySoundOnDrop;
             txtFilterFile.Text = MapAssistConfiguration.Loaded.ItemLog.FilterFileName;
             txtSoundFile.Text = MapAssistConfiguration.Loaded.ItemLog.SoundFile;
@@ -590,9 +590,9 @@ namespace MapAssist
             MapAssistConfiguration.Loaded.ItemLog.CheckItemOnIdentify = chkItemLogItemsOnIdentify.Checked;
         }
 
-        private void chkItemLogVendorTrade_CheckedChanged(object sender, EventArgs e)
+        private void chkItemLogVendorItems_CheckedChanged(object sender, EventArgs e)
         {
-            MapAssistConfiguration.Loaded.ItemLog.CheckVendorTrade = chkItemLogVendorTrade.Checked;
+            MapAssistConfiguration.Loaded.ItemLog.CheckVendorItems = chkItemLogVendorItems.Checked;
         }
 
         private void cboItemLogPosition_SelectedIndexChanged(object sender, EventArgs e)

--- a/Helpers/GameMemory.cs
+++ b/Helpers/GameMemory.cs
@@ -123,7 +123,11 @@ namespace MapAssist.Helpers
                 }
 
                 // Check if new game
-                if (mapSeed != _lastMapSeeds[_currentProcessId])
+                if (mapSeed == _lastMapSeeds[_currentProcessId])
+                {
+                    _playerMapChanged[_currentProcessId] = false;
+                }
+                else
                 {
                     UpdateMemoryData();
                     _lastMapSeeds[_currentProcessId] = mapSeed;
@@ -195,18 +199,18 @@ namespace MapAssist.Helpers
                 {
                     if (Items.ItemUnitIdsToSkip[_currentProcessId].Contains(item.UnitId)) continue;
 
-                    if (_playerMapChanged[_currentProcessId] && item.IsPlayerHolding && item.Item != Item.HoradricCube && !Items.ItemUnitIdsToSkip[_currentProcessId].Contains(item.UnitId))
+                    if (_playerMapChanged[_currentProcessId] && item.IsAnyPlayerHolding && item.Item != Item.HoradricCube && !Items.ItemUnitIdsToSkip[_currentProcessId].Contains(item.UnitId))
                     {
                         Items.ItemUnitIdsToSkip[_currentProcessId].Add(item.UnitId);
                         continue;
                     }
 
-                    if (item.IsIdentifiedInPlayerInventory && !Items.InventoryItemUnitIdsToSkip[_currentProcessId].Contains(item.UnitId))
+                    if (item.IsPlayerOwned && item.IsIdentified && !Items.InventoryItemUnitIdsToSkip[_currentProcessId].Contains(item.UnitId))
                     {
                         item.IsCached = false;
                     }
 
-                    var identifiedPreUpdate = item.IsIdentified;
+                    var enableInventoryFilterCheck = item.IsIdentified && item.IsPlayerOwned;
 
                     item.Update();
 
@@ -231,7 +235,7 @@ namespace MapAssist.Helpers
                         }
                     }
 
-                    if (item.IsValidItem && (item.IsDropped && !item.IsIdentified || item.IsIdentified && item.IsInStore || (identifiedPreUpdate && item.IsIdentifiedInPlayerInventory)))
+                    if (item.IsValidItem && ((item.IsDropped && !item.IsIdentified) || (item.IsIdentified && item.IsInStore) || enableInventoryFilterCheck))
                     {
                         Items.LogItem(item, _currentProcessId);
                     }
@@ -281,7 +285,6 @@ namespace MapAssist.Helpers
                 }
 
                 // Return data
-                _playerMapChanged[_currentProcessId] = false;
                 _firstMemoryRead = false;
                 _errorThrown = false;
 

--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -48,16 +48,14 @@ namespace MapAssist.Helpers
             // So we know that simply having the name match means we can return true
             if (matches.Any(kv => kv.Value == null))
             {
-                return (!item.IsPlayerHolding, null);
+                return (!item.IsAnyPlayerHolding, null);
             }
 
             // Scan the list of rules
             foreach (var rule in matches.SelectMany(kv => kv.Value))
             {
-                if (item.IsIdentified && !rule.FilterRequiresItemIsIdentified())
-                {
-                    continue;
-                }
+                // Skip generic unid rules for identified items
+                if (item.IsIdentified && rule.TargetsUnidItem()) continue;
 
                 // Requirement check functions
                 var requirementsFunctions = new Dictionary<string, Func<bool>>()

--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -22,7 +22,6 @@ using MapAssist.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using YamlDotNet.Serialization;
 
 namespace MapAssist.Helpers
 {
@@ -47,11 +46,23 @@ namespace MapAssist.Helpers
             // Early breakout
             // We know that there is an item in here without any actual filters
             // So we know that simply having the name match means we can return true
-            if (matches.Any(kv => kv.Value == null)) return (true, null);
+            if (matches.Any(kv => kv.Value == null))
+            {
+                if (item.IsPlayerHolding)
+                {
+                    return (false, null);
+                }
+                return (true, null);
+            }
 
             // Scan the list of rules
             foreach (var rule in matches.SelectMany(kv => kv.Value))
             {
+                if (item.IsIdentified && !rule.FilterRequiresItemIsIdentified())
+                {
+                    continue;
+                }
+
                 // Requirement check functions
                 var requirementsFunctions = new Dictionary<string, Func<bool>>()
                 {

--- a/Helpers/LootFilter.cs
+++ b/Helpers/LootFilter.cs
@@ -48,11 +48,7 @@ namespace MapAssist.Helpers
             // So we know that simply having the name match means we can return true
             if (matches.Any(kv => kv.Value == null))
             {
-                if (item.IsPlayerHolding)
-                {
-                    return (false, null);
-                }
-                return (true, null);
+                return (!item.IsPlayerHolding, null);
             }
 
             // Scan the list of rules

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -144,12 +144,6 @@ Short Staff:
     All Skills: 1
     PlaySoundOnDrop: false
 
-# This will show Barbarian Warcry Sticks when a town vendor has them for sale
-Glaive:
-  - Qualities: magic
-    Class Skill Tree:
-      Barbarian Warcries: 3
-
 # This is just an object that holds all our commonly used aliases
 # Aliases are labeled by the `&` and then the name and provide a simple way to reuse rule criteria later on
 # They are used by referencing `*` then the name as you'll see in the Mercenary section of this config
@@ -174,9 +168,47 @@ x-bases:
     All Resist: 25
     Sockets: [0, 4]
 
-# This ring rule will show all magic, rare, and unique rings
+# Unidentified item filter rules can use any criteria in this template:
+# <Item Class | Item Base Name>:
+#   Tiers:
+#   Qualities:
+#   Sockets:
+#   Ethereal:
+#   PlaySoundOnDrop:
+#
+# This ring rule will show all unidentified magic, rare, and unique rings that drop on the ground
 Ring:
   - Qualities: [magic, rare, unique]
+  # The rings below have stats that are only possible on identified items, so these rules
+  # will alert you when a matching item is identified by you or picked up as identified
+  - Qualities: magic
+    Magic Find: 40
+  - Qualities: magic
+    Faster Cast Rate: 10
+    Max Mana: 120
+  - Qualities: magic
+    Magic Find: 15
+    Max Mana: 120
+  - Qualities: magic
+    Faster Cast Rate: 10
+    Fire Resist: 15
+    Lightning Resist: 15
+  - Qualities: magic
+    Magic Find: 15
+    Fire Resist: 15
+    Lightning Resist: 15
+  - Qualities: rare
+    Faster Cast Rate: 10
+    Max Mana: 80
+    All Resist: 10
+  - Qualities: unique # SoJ or BK ring
+    All Skills: 1
+
+# This will show Barbarian Warcry Sticks when you trade a town vendor that has them for sale
+Glaive:
+  - Qualities: magic
+    Class Skill Tree:
+      Barbarian Warcries: 3
 
 ### Some items are inactive
 ### To activate them for the loot log, remove the ## in front of them

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -1,3 +1,24 @@
+Any:
+  - Strength: 1
+  - Dexterity: 1
+  - Vitality: 1
+  - Energy: 1
+  - Max Life: 1
+  - Max Mana: 1
+  - Attack Rating: 1
+  - Life Steal: 1
+  - Mana Steal: 1
+  - Increased Attack Speed: 1
+  - Faster Hit Recovery: 1
+  - Faster Cast Rate: 1
+  - Magic Find: 1
+  - Gold Find: 1
+  - All Resist: 1
+  - Cold Resist: 1
+  - Lightning Resist: 1
+  - Fire Resist: 1
+  - Poison Resist: 1
+
 # IMPORTANT: After changing anything in this file, ensure validity using https://jsonformatter.org/yaml-validator
 
 # Item filter rules

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -172,6 +172,7 @@ x-bases:
 # <Item Class | Item Base Name>:
 #   Tiers:
 #   Qualities:
+#   Defense:
 #   Sockets:
 #   Ethereal:
 #   PlaySoundOnDrop:

--- a/ItemFilter.yaml
+++ b/ItemFilter.yaml
@@ -1,24 +1,3 @@
-Any:
-  - Strength: 1
-  - Dexterity: 1
-  - Vitality: 1
-  - Energy: 1
-  - Max Life: 1
-  - Max Mana: 1
-  - Attack Rating: 1
-  - Life Steal: 1
-  - Mana Steal: 1
-  - Increased Attack Speed: 1
-  - Faster Hit Recovery: 1
-  - Faster Cast Rate: 1
-  - Magic Find: 1
-  - Gold Find: 1
-  - All Resist: 1
-  - Cold Resist: 1
-  - Lightning Resist: 1
-  - Fire Resist: 1
-  - Poison Resist: 1
-
 # IMPORTANT: After changing anything in this file, ensure validity using https://jsonformatter.org/yaml-validator
 
 # Item filter rules

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -165,40 +165,30 @@ namespace MapAssist.Settings
 
     public static class ItemFilterExtensions
     {
-        public static bool FilterRequiresItemIsIdentified(this ItemFilter rule)
+        public static bool TargetsUnidItem(this ItemFilter rule)
         {
-            if (rule == null) return false;
-
-            var unidentifiedProps = new List<string>()
-            {
-                "Ethereal",
-                "Defense",
-                "PlaySoundOnDrop",
-                "Qualities",
-                "Sockets",
-                "Tiers",
-            };
+            if (rule == null) return true;
 
             foreach (var property in rule.GetType().GetProperties())
             {
-                var propType = property.PropertyType;
-                if (propType == typeof(object)) continue; // This is the item from Stat property
+                if (property.Name == "Defense") continue;
 
-                if (unidentifiedProps.Contains(property.Name)) continue;
+                var propType = property.PropertyType;
+                if (propType == typeof(object)) continue;
 
                 var propertyValue = rule.GetType().GetProperty(property.Name).GetValue(rule, null);
                 if (propertyValue != null && propType == typeof(int?) && (int)propertyValue > 0)
                 {
-                    return true;
+                    return false;
                 }
             }
 
-            if (rule.Skills.Where(subrule => subrule.Value != null).Count() > 0) return true;
-            if (rule.SkillCharges.Where(subrule => subrule.Value != null).Count() > 0) return true;
-            if (rule.ClassSkills.Where(subrule => subrule.Value != null).Count() > 0) return true;
-            if (rule.ClassTabSkills.Where(subrule => subrule.Value != null).Count() > 0) return true;
+            if (rule.Skills.Where(subrule => subrule.Value != null).Count() > 0) return false;
+            if (rule.SkillCharges.Where(subrule => subrule.Value != null).Count() > 0) return false;
+            if (rule.ClassSkills.Where(subrule => subrule.Value != null).Count() > 0) return false;
+            if (rule.ClassTabSkills.Where(subrule => subrule.Value != null).Count() > 0) return false;
 
-            return false;
+            return true;
         }
     }
 }

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -169,16 +169,22 @@ namespace MapAssist.Settings
         {
             if (rule == null) return false;
 
+            var unidentifiedProps = new List<string>()
+            {
+                "Ethereal",
+                "Defense",
+                "PlaySoundOnDrop",
+                "Qualities",
+                "Sockets",
+                "Tiers",
+            };
+
             foreach (var property in rule.GetType().GetProperties())
             {
                 var propType = property.PropertyType;
                 if (propType == typeof(object)) continue; // This is the item from Stat property
 
-                var propName = property.Name;
-                if (propName == "Qualities" || propName == "Ethereal" || propName == "Tiers" || propName == "Sockets" || propName == "PlaySoundOnDrop")
-                {
-                    continue;
-                }
+                if (unidentifiedProps.Contains(property.Name)) continue;
 
                 var propertyValue = rule.GetType().GetProperty(property.Name).GetValue(rule, null);
                 if (propertyValue != null && propType == typeof(int?) && (int)propertyValue > 0)

--- a/Settings/LootLogConfiguration.cs
+++ b/Settings/LootLogConfiguration.cs
@@ -162,4 +162,37 @@ namespace MapAssist.Settings
         [YamlMember(Alias = "Skill Charges")]
         public Dictionary<Skill, int?> SkillCharges { get; set; } = new Dictionary<Skill, int?>();
     }
+
+    public static class ItemFilterExtensions
+    {
+        public static bool FilterRequiresItemIsIdentified(this ItemFilter rule)
+        {
+            if (rule == null) return false;
+
+            foreach (var property in rule.GetType().GetProperties())
+            {
+                var propType = property.PropertyType;
+                if (propType == typeof(object)) continue; // This is the item from Stat property
+
+                var propName = property.Name;
+                if (propName == "Qualities" || propName == "Ethereal" || propName == "Tiers" || propName == "Sockets" || propName == "PlaySoundOnDrop")
+                {
+                    continue;
+                }
+
+                var propertyValue = rule.GetType().GetProperty(property.Name).GetValue(rule, null);
+                if (propertyValue != null && propType == typeof(int?) && (int)propertyValue > 0)
+                {
+                    return true;
+                }
+            }
+
+            if (rule.Skills.Where(subrule => subrule.Value != null).Count() > 0) return true;
+            if (rule.SkillCharges.Where(subrule => subrule.Value != null).Count() > 0) return true;
+            if (rule.ClassSkills.Where(subrule => subrule.Value != null).Count() > 0) return true;
+            if (rule.ClassTabSkills.Where(subrule => subrule.Value != null).Count() > 0) return true;
+
+            return false;
+        }
+    }
 }

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -262,8 +262,8 @@ public class ItemLogConfiguration
     [YamlMember(Alias = "FilterFileName", ApplyNamingConventions = false)]
     public string FilterFileName { get; set; }
 
-    [YamlMember(Alias = "CheckVendorTrade", ApplyNamingConventions = false)]
-    public bool CheckVendorTrade { get; set; }
+    [YamlMember(Alias = "CheckVendorItems", ApplyNamingConventions = false)]
+    public bool CheckVendorItems { get; set; }
 
     [YamlMember(Alias = "CheckItemOnIdentify", ApplyNamingConventions = false)]
     public bool CheckItemOnIdentify { get; set; }

--- a/Settings/MapAssistConfiguration.cs
+++ b/Settings/MapAssistConfiguration.cs
@@ -262,6 +262,12 @@ public class ItemLogConfiguration
     [YamlMember(Alias = "FilterFileName", ApplyNamingConventions = false)]
     public string FilterFileName { get; set; }
 
+    [YamlMember(Alias = "CheckVendorTrade", ApplyNamingConventions = false)]
+    public bool CheckVendorTrade { get; set; }
+
+    [YamlMember(Alias = "CheckItemOnIdentify", ApplyNamingConventions = false)]
+    public bool CheckItemOnIdentify { get; set; }
+
     [YamlMember(Alias = "PlaySoundOnDrop", ApplyNamingConventions = false)]
     public bool PlaySoundOnDrop { get; set; }
 

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -195,15 +195,12 @@ namespace MapAssist.Types
                 var yamlAttribute = property.CustomAttributes.FirstOrDefault(x => x.AttributeType == typeof(YamlMemberAttribute));
                 var propName = property.Name;
 
-                if (propName == "AllSkills" || propName == "AllResist" || propName == "MaxLife" || propName == "MaxMana")
-                {
-                    continue;
-                }
-
                 if (yamlAttribute != null) propName = yamlAttribute.NamedArguments.FirstOrDefault(x => x.MemberName == "Alias").TypedValue.Value.ToString();
 
                 if (property.PropertyType == typeof(int?) && Enum.TryParse<Stat>(property.Name, out var stat))
                 {
+                    if (stat == Stat.AllSkills || stat == Stat.MaxLife || stat == Stat.MaxMana) continue;
+
                     var propertyValue = rule.GetType().GetProperty(property.Name).GetValue(rule, null);
                     if (propertyValue == null) continue;
 

--- a/Types/Items.cs
+++ b/Types/Items.cs
@@ -50,7 +50,7 @@ namespace MapAssist.Types
                     ItemUnitHashesSeen[processId].Add(item.HashString);
                 }
 
-                if (item.IsIdentifiedInPlayerInventory)
+                if (item.IsPlayerOwned && item.IsIdentified)
                 {
                     InventoryItemUnitIdsToSkip[processId].Add(item.UnitId);
                     ItemUnitIdsToSkip[processId].Add(item.UnitId);
@@ -77,7 +77,7 @@ namespace MapAssist.Types
         }
 
         private static bool CheckInventoryItem(UnitItem item, int processId) =>
-            item.IsIdentifiedInPlayerInventory &&
+            item.IsIdentified && item.IsPlayerOwned &&
             !InventoryItemUnitIdsToSkip[processId].Contains(item.UnitId);
 
         private static bool CheckDroppedItem(UnitItem item, int processId) =>
@@ -103,7 +103,7 @@ namespace MapAssist.Types
                 var vendorLabel = item.VendorOwner != Npc.Unknown ? NpcExtensions.Name(item.VendorOwner) : "Vendor";
                 itemPrefix += $"[{vendorLabel}] ";
             }
-            else if (item.IsIdentifiedInPlayerInventory)
+            else if (item.IsIdentified)
             {
                 itemPrefix += "[Identified] ";
             }

--- a/Types/UnitItem.cs
+++ b/Types/UnitItem.cs
@@ -9,6 +9,7 @@ namespace MapAssist.Types
     public class UnitItem : UnitAny
     {
         public ItemData ItemData { get; private set; }
+        public new bool IsPlayerOwned { get; set; } = false;
         public Npc VendorOwner { get; set; } = Npc.Invalid;
         public Item Item => (Item)TxtFileNo;
         public ItemMode ItemMode => (ItemMode)Struct.Mode;
@@ -43,6 +44,8 @@ namespace MapAssist.Types
         public bool IsValidItem => !_isInvalid && UnitId != uint.MaxValue;
 
         public bool IsIdentified => ItemData.ItemQuality >= ItemQuality.MAGIC && (ItemData.ItemFlags & ItemFlags.IFLAG_IDENTIFIED) == ItemFlags.IFLAG_IDENTIFIED;
+
+        public bool IsIdentifiedInPlayerInventory => IsPlayerOwned && IsIdentified && IsPlayerHolding;
 
         public bool IsDropped => ItemModeMapped == ItemModeMapped.Ground;
 
@@ -95,7 +98,7 @@ namespace MapAssist.Types
                 return ItemModeMapped.Unknown; // Items that appeared in the trade window before will appear here
             }
         }
-
+        
         public override string HashString => Item + "/" + Position.X + "/" + Position.Y;
     }
 }

--- a/Types/UnitItem.cs
+++ b/Types/UnitItem.cs
@@ -45,13 +45,11 @@ namespace MapAssist.Types
 
         public bool IsIdentified => ItemData.ItemQuality >= ItemQuality.MAGIC && (ItemData.ItemFlags & ItemFlags.IFLAG_IDENTIFIED) == ItemFlags.IFLAG_IDENTIFIED;
 
-        public bool IsIdentifiedInPlayerInventory => IsPlayerOwned && IsIdentified && IsPlayerHolding;
-
         public bool IsDropped => ItemModeMapped == ItemModeMapped.Ground;
 
         public bool IsInStore => ItemModeMapped == ItemModeMapped.Vendor;
 
-        public bool IsPlayerHolding
+        public bool IsAnyPlayerHolding
         {
             get
             {


### PR DESCRIPTION
Loot Filter alerts for items on identify
- Requires player to be holding a Horadric Cube (used to match items `dwOwnerID` to player)
- If an item is picked up or identified matching a loot filter rule the item will alert and log with an `[Identified]` tag

It is possible for an item to alert two times with this change (based on ItemFilter configuration).  

In the default config, any unidentified magic, rare, or unique rings that drops will alert.  If a magic ring is identified or picked up having 40 magic find, an additional alert will occur.  I put a few more ring rules in the default config to provide more examples.

Added two new Item Log settings under the "Enabled" checkbox
- Check Items on Identify
- Check Vendor Items (*changed after screenshot was taken)
![gui](https://user-images.githubusercontent.com/10291543/150695019-0c441523-4239-43c7-8c25-90110a6c1781.png)